### PR TITLE
Issue #17: EntitySpaces Studio Connection reverts to Northwind when you save project

### DIFF
--- a/Studio/CodeGeneration/ClassLibraries/EntitySpaces.Common/esProject.cs
+++ b/Studio/CodeGeneration/ClassLibraries/EntitySpaces.Common/esProject.cs
@@ -24,7 +24,7 @@ namespace EntitySpaces.Common
 
             string version = GetFileVersion(fileNameAndFilePath);
 
-            if (version != null && version.Substring(0, 4) != "2011" && version.Substring(0, 4) != "2012")
+            if (version?.Length >= 4 && version.Substring(0, 4) != "0000" && string.Compare(version.Substring(0, 4), "2011") < 0)
             {
                 // Convert the old project file in place
                 ConvertProject(fileNameAndFilePath, mainSettings);

--- a/Studio/CodeGeneration/ClassLibraries/EntitySpaces.MetadataEngine/esPlugIn/esSettings.cs
+++ b/Studio/CodeGeneration/ClassLibraries/EntitySpaces.MetadataEngine/esPlugIn/esSettings.cs
@@ -571,7 +571,7 @@ namespace EntitySpaces.MetadataEngine
 
             string version = GetFileVersion(pathAndFileName);
 
-            if (version.Substring(0, 4) != "2011" && version.Substring(0, 4) != "2012")
+            if (version?.Length >= 4 && version.Substring(0, 4) != "0000" && string.Compare(version.Substring(0, 4), "2011") < 0)
             {
                 // Convert the old project file in place
                 ConvertSettings(pathAndFileName);


### PR DESCRIPTION
The problem was that when the version number in the project/settings file is 2019, the code tries to upgrade from 2010 to 2012 when the file is loaded.  I've made it so that this won't happen.