### PR TITLE
fix for primary key result by replaced the SELECT next sequence value with RETURN

### DIFF
--- a/Providers/EntitySpaces.PostgreSQLProvider/Shared.cs
+++ b/Providers/EntitySpaces.PostgreSQLProvider/Shared.cs
@@ -81,11 +81,7 @@ namespace EntitySpaces.Npgsql2Provider
 
                     if (sequence != null && sequence.Length > 0)
                     {
-                        // Our identity column ...
-                        p = cmd.Parameters.Add(CloneParameter(types[col.Name]));
-                        p.Direction = ParameterDirection.Output;
-
-                        autoInc += " SELECT * FROM " + sequence + " as \"" + col.Name + "\"";
+                        autoInc += " RETURNING \"" + col.Name + "\";";
                     }
                     
                     p = CloneParameter(types[col.Name]);
@@ -237,7 +233,7 @@ namespace EntitySpaces.Npgsql2Provider
 
             if (into.Length != 0)
             {
-                sql += " (" + into + ") VALUES (" + values + ");";
+                sql += " (" + into + ") VALUES (" + values + ")";
             }
             else
             {


### PR DESCRIPTION
This issue is happening with the AutoIncrement column. The problem was new record is getting saved to DB and the object doesn't have a primary key set after a successful transaction. I've made it so the object would set the DB's primary key set after the transaction complete. 
